### PR TITLE
added access to Get_Seg_Mask

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ luarocks make
 ```
 
 
-## Demo
+## Demos
 
 ```bash
-qlua demo.lua
+qlua visual_demo.lua input.jpg
+th seg_mask_demo.lua input.jpg output.dat
 ```

--- a/init.cpp
+++ b/init.cpp
@@ -57,6 +57,18 @@ void gSLICr_process()
 }
 
 extern "C"
+void gSLICr_get_seg(float *output)
+{
+   const gSLICr::IntImage* idx_img = gSLICr_engine->Get_Seg_Res();
+   const int* data_ptr = idx_img->GetData(MEMORYDEVICE_CPU);
+
+   int idx_img_size = idx_img->noDims.x * idx_img->noDims.y;
+   for (int i = 0; i < idx_img_size; i++) {
+      output[i] = data_ptr[i];
+   }
+}
+
+extern "C"
 void gSLICr_retrieve(uint8_t *output)
 {
    gSLICr_engine->Draw_Segmentation_Result(out_img);

--- a/init.lua
+++ b/init.lua
@@ -7,6 +7,7 @@ void gSLICr_init(int x, int y, int no_segs, int spixel_size,
                  int seg_method, bool do_enforce_connectivity);
 void gSLICr_feed(uint8_t *input);
 void gSLICr_process();
+void gSLICr_get_seg(float *output);
 void gSLICr_retrieve(uint8_t *output);
 ]]
 
@@ -51,6 +52,10 @@ end
 
 function gSLICr.process()
    gSLICr.C['gSLICr_process']()
+end
+
+function gSLICr.get_seg(output)
+   gSLICr.C['gSLICr_get_seg'](torch.data(output))
 end
 
 function gSLICr.retrieve(output)

--- a/seg_mask_demo.lua
+++ b/seg_mask_demo.lua
@@ -1,0 +1,38 @@
+require('torch')
+torch.setdefaulttensortype('torch.FloatTensor')
+require('sys')
+require('image')
+local gSLICr = require('gSLICr')
+
+
+if arg[1] and not arg[2] then
+   print('Must specify both an input and output file')
+   print(' ... or for Lena demo, exclude all arguments')
+   os.exit()
+end
+
+local input = (arg[1] and image.load(arg[1])) or image.lena()
+local output_file = arg[2] or 'lena_spixels.dat'
+
+input = input:mul(255):byte()
+local output = torch.FloatTensor(input:size(2), input:size(3))
+
+
+gSLICr.init({x = input:size(3),
+             y = input:size(2),
+             coh_weight = 8,
+             no_segs = 512,
+             spixel_size = 32,
+             seg_method = 1,  -- 0: use no_segs,  1: use spixel_size
+            })
+
+sys.tic()
+gSLICr.feed(input)
+gSLICr.process()
+gSLICr.get_seg(output)
+local seg_time = sys.toc()
+
+print(torch.max(output) .. ' superpixels in ' .. seg_time .. ' seconds')
+
+print('Saving serialized segmentation mask to ' .. output_file)
+torch.save(output_file, output)

--- a/visual_demo.lua
+++ b/visual_demo.lua
@@ -8,7 +8,13 @@ local input = (arg[1] and image.load(arg[1])) or image.lena()
 input = input:mul(255):byte()
 local output = input:clone():zero()
 
-gSLICr.init({x = input:size(3), y = input:size(2)})
+gSLICr.init({x = input:size(3),
+             y = input:size(2),
+             coh_weight = 8,
+             no_segs = 512,
+             spixel_size = 32,
+             seg_method = 1,  -- 0: use no_segs,  1: use spixel_size
+            })
 gSLICr.feed(input)
 gSLICr.process()
 gSLICr.retrieve(output)


### PR DESCRIPTION
It is now possible to get the segmentation mask from gSLICr by calling the Lua function gSLICr.get_seg.  This function takes one argument which must be a 2 dimensional torch.FloatTensor with height and width equal to the dimensions of the image which has been segmented.  After calling gSLICr.get_seg, this torch.FloatTensor will hold the segmentation mask.
